### PR TITLE
fix: RoutesListBuilder correctly not showing widget based on states issue

### DIFF
--- a/lib/domain/api_utils/api_query.dart
+++ b/lib/domain/api_utils/api_query.dart
@@ -15,7 +15,7 @@ class APIQuery {
 
   APIQuery(
       {this.categoryType,
-      this.limit,
+      this.limit = 5,
       this.page,
       this.postId,
       this.searchedRouteQuery});

--- a/lib/ui/sections/hero_home/hero_home_screen.dart
+++ b/lib/ui/sections/hero_home/hero_home_screen.dart
@@ -48,16 +48,14 @@ class _HeroHomeScreenState extends State<HeroHomeScreen> {
     if (kDebugMode) {
       print("initStateCalled  :HeroHomeScreen");
     }
-    _trendingRouteBloc = PostRouteCubit(
-        postRouteRepo: context.read<PostRouteRepo>())
-      ..getRoutesByCategory(
-          query:
-              APIQuery(categoryType: CategoryType.trendingRoutes, limit: 10));
-    _suggestedRouteBloc = PostRouteCubit(
-        postRouteRepo: context.read<PostRouteRepo>())
-      ..getRoutesByCategory(
-          query:
-              APIQuery(categoryType: CategoryType.suggestedRoutes, limit: 10));
+    _trendingRouteBloc =
+        PostRouteCubit(postRouteRepo: context.read<PostRouteRepo>())
+          ..getRoutesByCategory(
+              query: APIQuery(categoryType: CategoryType.trendingRoutes));
+    _suggestedRouteBloc =
+        PostRouteCubit(postRouteRepo: context.read<PostRouteRepo>())
+          ..getRoutesByCategory(
+              query: APIQuery(categoryType: CategoryType.suggestedRoutes));
     _selectedDateNotifier = ValueNotifier(DateTime.now());
   }
 
@@ -89,9 +87,9 @@ class _HeroHomeScreenState extends State<HeroHomeScreen> {
       ..clearRoutes()
       ..updatePage();
     _trendingRouteBloc.getRoutesByCategory(
-        query: APIQuery(categoryType: CategoryType.trendingRoutes, limit: 10));
+        query: APIQuery(categoryType: CategoryType.trendingRoutes));
     _suggestedRouteBloc.getRoutesByCategory(
-        query: APIQuery(categoryType: CategoryType.suggestedRoutes, limit: 10));
+        query: APIQuery(categoryType: CategoryType.suggestedRoutes));
   }
 
   Row _actionWidgets(BuildContext context) {

--- a/lib/ui/sections/hero_home/widgets/route_list_builder.dart
+++ b/lib/ui/sections/hero_home/widgets/route_list_builder.dart
@@ -98,9 +98,8 @@ class _RoutesListBuilderState extends State<RoutesListBuilder> {
   Widget build(BuildContext context) {
     return BlocBuilder<PostRouteCubit, PostRouteState>(
       builder: (context, state) {
-        if (state.status == BlocStatus.fetchFailed ||
-            state.status == BlocStatus.fetchFailed &&
-                state.routeModels.isNotEmpty) {
+        if (state.status == BlocStatus.fetchFailed &&
+            state.routeModels.isEmpty) {
           return const RouteFetchedFailWidget();
         } else if (state.status == BlocStatus.fetching &&
             state.routeModels.isEmpty) {

--- a/lib/ui/sections/hot_and_trending/trending_routes_card.dart
+++ b/lib/ui/sections/hot_and_trending/trending_routes_card.dart
@@ -31,7 +31,7 @@ class _TrendingRoutesCardState extends State<TrendingRoutesCard> {
     super.initState();
     _trendingRouteBloc = context.read<PostRouteCubit>()
       ..getRoutesByCategory(
-          query: APIQuery(categoryType: CategoryType.trendingRoutes, limit: 5));
+          query: APIQuery(categoryType: CategoryType.trendingRoutes));
   }
 
   @override

--- a/lib/ui/sections/search/search_query_routes.dart
+++ b/lib/ui/sections/search/search_query_routes.dart
@@ -55,7 +55,6 @@ class _SearchQueryRoutesState extends State<SearchQueryRoutes> {
           ..getRoutesByCategory(
               query: APIQuery(
                   categoryType: CategoryType.searchedRoutes,
-                  limit: 5,
                   searchedRouteQuery: searchRoutesQuery));
       }
       _initial = false;

--- a/lib/ui/sections/upload/route_array_upload/ui/trending_routes_screen.dart
+++ b/lib/ui/sections/upload/route_array_upload/ui/trending_routes_screen.dart
@@ -28,7 +28,7 @@ class _TrendingRoutesScreenState extends State<TrendingRoutesScreen> {
   void initState() {
     _trendingRouteCubit = context.read<PostRouteCubit>()
       ..getRoutesByCategory(
-          query: APIQuery(categoryType: CategoryType.trendingRoutes, limit: 5));
+          query: APIQuery(categoryType: CategoryType.trendingRoutes));
     super.initState();
   }
 
@@ -46,8 +46,7 @@ class _TrendingRoutesScreenState extends State<TrendingRoutesScreen> {
     return RefreshIndicator.adaptive(
       onRefresh: () async {
         _trendingRouteCubit.getRoutesByCategory(
-            query:
-                APIQuery(categoryType: CategoryType.trendingRoutes, limit: 5));
+            query: APIQuery(categoryType: CategoryType.trendingRoutes));
       },
       child: CustomScrollView(
         slivers: [

--- a/lib/ui/widgets/show_routes_by_category/show_routes_by_category_screen.dart
+++ b/lib/ui/widgets/show_routes_by_category/show_routes_by_category_screen.dart
@@ -58,10 +58,8 @@ class _ShowRoutesByCategoryScreenState
   void initState() {
     print("initStateCalled  :HotAndTrendingScreen");
     super.initState();
-    initialQuery =
-        APIQuery(categoryType: CategoryType.trendingRoutes, limit: 10);
-    getPostWithRouteQuery =
-        APIQuery(categoryType: CategoryType.postWithRoutes, limit: 10);
+    initialQuery = APIQuery(categoryType: CategoryType.trendingRoutes);
+    getPostWithRouteQuery = APIQuery(categoryType: CategoryType.postWithRoutes);
 
     _postRouteCubit = context.read<PostRouteCubit>();
     context.read<CityCubit>().fetchCities();
@@ -197,7 +195,6 @@ class _ShowRoutesByCategoryScreenState
               destination: getRandomCity(),
             );
             query = APIQuery(
-                limit: 5,
                 categoryType: CategoryType.searchedRoutes,
                 searchedRouteQuery: searchedRouteQuery);
             context.pushNamed(RouteLists.searchRoutesScreen,

--- a/test/bloc/post_route/post_route_cubit_test.dart
+++ b/test/bloc/post_route/post_route_cubit_test.dart
@@ -140,8 +140,7 @@ void main() {
               )).thenAnswer((_) async => routes);
         },
         act: (cubit) => cubit.getRoutesByCategory(
-          query:
-              APIQuery(categoryType: CategoryType.suggestedRoutes, limit: 10),
+          query: APIQuery(categoryType: CategoryType.suggestedRoutes, limit: 5),
         ),
         expect: () => [
           const PostRouteState(status: BlocStatus.fetching),
@@ -162,7 +161,7 @@ void main() {
               )).thenThrow(Exception('Fetch failed'));
         },
         act: (cubit) => cubit.getRoutesByCategory(
-          query: APIQuery(categoryType: CategoryType.trendingRoutes, limit: 10),
+          query: APIQuery(categoryType: CategoryType.trendingRoutes, limit: 5),
         ),
         expect: () => [
           const PostRouteState(status: BlocStatus.fetching),
@@ -201,7 +200,7 @@ void main() {
             },
             act: (cubit) => cubit.getRoutesByCategory(
               query: APIQuery(
-                  categoryType: CategoryType.suggestedRoutes, limit: 10),
+                  categoryType: CategoryType.suggestedRoutes, limit: 5),
             ),
             seed: () => PostRouteState(routeModels: routes),
             expect: () => [
@@ -231,7 +230,7 @@ void main() {
               )).thenAnswer((_) async => posts);
         },
         act: (cubit) => cubit.getPostWithRoutes(
-          query: APIQuery(categoryType: CategoryType.postWithRoutes, limit: 10),
+          query: APIQuery(categoryType: CategoryType.postWithRoutes, limit: 5),
         ),
         expect: () => [
           const PostRouteState(status: BlocStatus.fetching),

--- a/test/ui/hero_home_screen/suggested_routes_list_test.dart
+++ b/test/ui/hero_home_screen/suggested_routes_list_test.dart
@@ -84,7 +84,7 @@ void main() {
       },
     );
     testWidgets(
-      "Render $RouteFetchedFailWidget when transition from ${BlocStatus.fetched} with data to ${BlocStatus.fetchFailed} ",
+      "Don't Render $RouteFetchedFailWidget when transition from ${BlocStatus.fetched} with data to ${BlocStatus.fetchFailed} ",
       (WidgetTester tester) async {
         final initialState =
             PostRouteState(routeModels: routes, status: BlocStatus.fetched);
@@ -102,7 +102,7 @@ void main() {
 
         expect(find.byType(RouteFetchingWidget), findsNothing);
         expect(find.byType(RouteFetchedEmptyWidget), findsNothing);
-        expect(find.byType(RouteFetchedFailWidget), findsOneWidget);
+        expect(find.byType(RouteFetchedFailWidget), findsNothing);
       },
     );
 

--- a/test/ui/hero_home_screen/trending_and_hot_route_list_test.dart
+++ b/test/ui/hero_home_screen/trending_and_hot_route_list_test.dart
@@ -85,7 +85,7 @@ void main() {
     );
 
     testWidgets(
-      "Render $RouteFetchedFailWidget when transition from ${BlocStatus.fetched} with data to ${BlocStatus.fetchFailed} ",
+      "Don't Render $RouteFetchedFailWidget when transition from ${BlocStatus.fetched} with data to ${BlocStatus.fetchFailed} ",
       (WidgetTester tester) async {
         final initialState =
             PostRouteState(routeModels: routes, status: BlocStatus.fetched);
@@ -103,7 +103,7 @@ void main() {
 
         expect(find.byType(RouteFetchingWidget), findsNothing);
         expect(find.byType(RouteFetchedEmptyWidget), findsNothing);
-        expect(find.byType(RouteFetchedFailWidget), findsOneWidget);
+        expect(find.byType(RouteFetchedFailWidget), findsNothing);
       },
     );
 


### PR DESCRIPTION
[fix: RoutesListBuilder still showing RouteFetchedFailWidget even stat…](https://github.com/thanwannahtun/link/commit/c5bd149af23a541f2c7b0e3b5086899a8bdd2328)

[perf: improve performance by setting default limit = 5 in APIQuery](https://github.com/thanwannahtun/link/commit/9b5d07640acf057f1b5e779c83dab69286be2de8)